### PR TITLE
Clean up GitHub issue template formatting

### DIFF
--- a/.github/ISSUE_TEMPLATE/ocwa-template.md
+++ b/.github/ISSUE_TEMPLATE/ocwa-template.md
@@ -49,12 +49,8 @@ assignees: BrandonSharratt
 
 ### ERROR
 
-<pre><code>
 <!-- If you have an associated exception or error, please post it below -->
-
-</code><pre>
 
 ## Notes
 
 <!-- Do any of these matter: Operating System, Browser? If so, please mention the version and any other relevant details below. -->
-* 

--- a/.github/ISSUE_TEMPLATE/ocwa-template.md
+++ b/.github/ISSUE_TEMPLATE/ocwa-template.md
@@ -1,37 +1,60 @@
 ---
 name: OCWA Template
-about: Template for all github issues
+about: Generic template for all GitHub issues
 title: ''
 labels: ''
 assignees: BrandonSharratt
-
 ---
 
-## _Use what you want. Remove what you don't want._
+# OCWA Issue
 
----
+<!-- Use what you want. Remove what you don't want. -->
+
 ## User Story
+
+<!-- Use one of the following two templates -->
+<!-- 1) User Story as a statement -->
+
 **As a** _< persona >_,<br>
 **I want** _< feature >_<br>
 **so that** _< reason >_.
 
----
-## User Story in a table
+<!-- 2) User Story as a table -->
+
 | **As A** | **I Want** | **So that** |
 |--------|---------|---------|
 | _< persona >_ | _< feature >_ | _< reason >_ |
 
----
 ## Test Case
 
-# ENV
-`PROD`, `CAT`, `CAD`
+### ENV
 
-# TESTCASE
-*
+<!-- Choose at least one of the following environments -->
+`DEV`, `TEST`, `PROD`
 
-# EXPECTED
-*
+### TESTCASE
 
-# ACTUAL
-*
+<!-- Share the minimal reproduction steps for this issue -->
+- 
+
+### EXPECTED
+
+<!-- Share the expected behavior of the testcase -->
+- 
+
+### ACTUAL
+
+<!-- Describe the actual behavior of the testcase -->
+- 
+
+### ERROR
+
+<pre><code>
+<!-- If you have an associated exception or error, please post it below -->
+
+</code><pre>
+
+## Notes
+
+<!-- Do any of these matter: Operating System, Browser? If so, please mention the version and any other relevant details below. -->
+* 

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,37 +1,60 @@
 ---
 name: OCWA Template
-about: Template for all github issues
+about: Generic template for all GitHub issues
 title: ''
 labels: ''
 assignees: BrandonSharratt
-
 ---
 
-## _Use what you want. Remove what you don't want._
+# OCWA Issue
 
----
+<!-- Use what you want. Remove what you don't want. -->
+
 ## User Story
+
+<!-- Use one of the following two templates -->
+<!-- 1) User Story as a statement -->
+
 **As a** _< persona >_,<br>
 **I want** _< feature >_<br>
 **so that** _< reason >_.
 
----
-## User Story in a table
+<!-- 2) User Story as a table -->
+
 | **As A** | **I Want** | **So that** |
 |--------|---------|---------|
 | _< persona >_ | _< feature >_ | _< reason >_ |
 
----
 ## Test Case
 
-# ENV
-`PROD`, `DEV`, `TEST`
+### ENV
 
-# TESTCASE
-*
+<!-- Choose at least one of the following environments -->
+`DEV`, `TEST`, `PROD`
 
-# EXPECTED
-*
+### TESTCASE
 
-# ACTUAL
-*
+<!-- Share the minimal reproduction steps for this issue -->
+- 
+
+### EXPECTED
+
+<!-- Share the expected behavior of the testcase -->
+- 
+
+### ACTUAL
+
+<!-- Describe the actual behavior of the testcase -->
+- 
+
+### ERROR
+
+<pre><code>
+<!-- If you have an associated exception or error, please post it below -->
+
+</code><pre>
+
+## Notes
+
+<!-- Do any of these matter: Operating System, Browser? If so, please mention the version and any other relevant details below. -->
+* 

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -49,12 +49,8 @@ assignees: BrandonSharratt
 
 ### ERROR
 
-<pre><code>
 <!-- If you have an associated exception or error, please post it below -->
-
-</code><pre>
 
 ## Notes
 
 <!-- Do any of these matter: Operating System, Browser? If so, please mention the version and any other relevant details below. -->
-* 


### PR DESCRIPTION
This change is mostly related to GitHub style formatting and making it so that:

1. it looks nicer to read with proper header levels
2. has comments masked away so that a person submitting an issue does not need to delete the instructional comments

Signed-off-by: Jeremy Ho <jujaga@gmail.com>