### PR TITLE
Fix missing output checker actions in request sidebar

### DIFF
--- a/frontend/server/app.js
+++ b/frontend/server/app.js
@@ -27,6 +27,7 @@ const cookieSecret = config.get('cookieSecret');
 const isDevelopment = process.env.NODE_ENV === 'development';
 const filesApiHost = config.get('filesApiHost');
 const forumSocket = config.get('forumSocket');
+const idField = config.get('user.idField');
 const memoryStore = new MemoryStore({
   checkPeriod: 86400000, // prune expired entries every 24h
 });
@@ -93,6 +94,7 @@ app.get('*', storeUrl, (req, res) => {
     filesApiHost: parseApiHost(filesApiHost),
     socketHost: parseWsHost(forumSocket),
     commit: get(process, 'env.GITHASH', ''),
+    idField,
   });
 });
 

--- a/frontend/server/views/index.pug
+++ b/frontend/server/views/index.pug
@@ -14,6 +14,7 @@ html
     window.FILES_API_HOST = !{JSON.stringify(filesApiHost)};
     window.SOCKET_HOST = !{JSON.stringify(socketHost)};
     window.COMMIT = !{JSON.stringify(commit)};
+    window.ID_FIELD = !{JSON.stringify(idField)};
 
   if isDevelopment
     script(src="/main.js")

--- a/frontend/src/modules/output-checker/components/request/sidebar.jsx
+++ b/frontend/src/modules/output-checker/components/request/sidebar.jsx
@@ -28,18 +28,19 @@ function Sidebar({
       <p>{data.author}</p>
       <h6>Reviewers</h6>
       {data.reviewers.length === 1 && <p>{assignedUser}</p>}
-      {data.reviewers.length <= 0 && (
-        <Button
-          appearance="link"
-          id="request-sidebar-pickup-button"
-          iconBefore={<AddCircleIcon primaryColor="green" />}
-          isDisabled={isSaving}
-          onClick={() => onPickupRequest(id)}
-        >
-          Assign to Me
-        </Button>
-      )}
-      {user.email === assignedUser &&
+      {data.reviewers.length <= 0 &&
+        data.state < 3 && (
+          <Button
+            appearance="link"
+            id="request-sidebar-pickup-button"
+            iconBefore={<AddCircleIcon primaryColor="green" />}
+            isDisabled={isSaving}
+            onClick={() => onPickupRequest(id)}
+          >
+            Assign to Me
+          </Button>
+        )}
+      {user.username === assignedUser &&
         data.state < 4 && (
           <React.Fragment>
             <h6>Actions</h6>

--- a/frontend/src/modules/output-checker/containers/requests.js
+++ b/frontend/src/modules/output-checker/containers/requests.js
@@ -5,19 +5,20 @@ import values from 'lodash/values';
 import withRequest from '@src/modules/data/components/data-request';
 import { fetchRequests } from '@src/modules/requests/actions';
 import { requestsListSchema } from '@src/modules/requests/schemas';
+import { idField } from '@src/services/config';
 
 import RequestsList from '../components/requests-list';
 
 const mapStateToProps = (state, { params }) => {
   const { filter, search } = state.outputChecker.viewState;
-  const user = get(state, 'app.auth.user.email');
+  const username = get(state, ['app', 'auth', 'user', idField]);
   const requests = values(state.data.entities.requests);
   const data = requests
     .filter(d => d.state === params.state)
     .filter(d => {
       switch (filter) {
         case 'mine':
-          return head(d.reviewers) === user;
+          return head(d.reviewers) === username;
         case 'unassigned':
           return d.reviewers.length === 0;
         default:

--- a/frontend/src/services/config.js
+++ b/frontend/src/services/config.js
@@ -2,9 +2,11 @@ export const limit = 100;
 
 export const version = VERSION;
 export const commit = COMMIT;
+export const idField = ID_FIELD;
 
 export default {
   commit,
   limit,
   version,
+  idField,
 };


### PR DESCRIPTION
`username` was added to the JWT and is used for assigning OC's to a request instead of `email` from before. In addition the UI uses the `user.idField` value to determine what to use as the username in any given deploy.