### PR TITLE
Fix search when results are not in first page's payload

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -79,6 +79,7 @@
     "@atlaskit/smart-card": "8.4.0",
     "@atlaskit/spinner": "^9.0.10",
     "@atlaskit/tabs": "^8.0.9",
+    "@atlaskit/textfield": "^0.1.6",
     "@atlaskit/util-shared-styles": "^3.0.0",
     "@babel/polyfill": "^7.0.0",
     "body-parser": "^1.18.3",

--- a/frontend/src/components/file-icon/index.jsx
+++ b/frontend/src/components/file-icon/index.jsx
@@ -70,7 +70,11 @@ function FileIcon({ type }) {
 }
 
 FileIcon.propTypes = {
-  type: PropTypes.string.isRequired,
+  type: PropTypes.string,
+};
+
+FileIcon.defaultProps = {
+  type: null,
 };
 
 export default FileIcon;

--- a/frontend/src/modules/requests/__tests__/sagas.test.js
+++ b/frontend/src/modules/requests/__tests__/sagas.test.js
@@ -1,4 +1,4 @@
-import { sanitizeURL } from '../sagas';
+import { sanitizeURL, syncFilesPayload } from '../sagas';
 
 describe('requests/sagas', () => {
   describe('utils', () => {
@@ -8,6 +8,14 @@ describe('requests/sagas', () => {
           'http://localhost:8000/files/cf30d725cfcfaf45723ec92448f7b458+e630147f2b9f0579'
         )
       ).toEqual('cf30d725cfcfaf45723ec92448f7b458');
+    });
+
+    it('should remove files queued to delete on autosave', () => {
+      expect(syncFilesPayload(['1', '2'], ['2'])).toEqual(['1']);
+      expect(syncFilesPayload(['1', '2', '3', '4'], ['2', '3'])).toEqual([
+        '1',
+        '4',
+      ]);
     });
   });
 });

--- a/frontend/src/modules/requests/actions.js
+++ b/frontend/src/modules/requests/actions.js
@@ -25,6 +25,10 @@ export const searchResults = filter => ({
   payload: filter,
 });
 
+export const clearSearch = () => ({
+  type: 'requests/search/clear',
+});
+
 export const changeStep = step => ({
   type: 'requests/change-step',
   payload: step,
@@ -99,6 +103,7 @@ export const downloadFile = id => ({
 export default {
   createRequest,
   changeStep,
+  clearSearch,
   closeDraftRequest,
   downloadFile,
   fetchRequests,

--- a/frontend/src/modules/requests/components/requests-list/index.jsx
+++ b/frontend/src/modules/requests/components/requests-list/index.jsx
@@ -9,7 +9,6 @@ import Date from '@src/components/date';
 import { DynamicTableStateless } from '@atlaskit/dynamic-table';
 import DocumentsIcon from '@atlaskit/icon/glyph/documents';
 import ErrorIcon from '@atlaskit/icon/glyph/error';
-import { FieldTextStateless } from '@atlaskit/field-text';
 import get from 'lodash/get';
 import head from 'lodash/head';
 import last from 'lodash/last';
@@ -18,9 +17,10 @@ import SearchIcon from '@atlaskit/icon/glyph/search';
 import { colors } from '@atlaskit/theme';
 import { limit } from '@src/services/config';
 
+import NewRequest from '../../containers/new-request';
 import RequestIcon from '../request-icon';
 import RequestMenu from '../../containers/request-menu';
-import NewRequest from '../../containers/new-request';
+import Search from '../../containers/search';
 import * as styles from './styles.css';
 
 const header = {
@@ -56,7 +56,6 @@ function RequestsList({
   isLoading,
   isLoaded,
   onChangeFilter,
-  onSearch,
   onSort,
   page,
   search,
@@ -171,14 +170,7 @@ function RequestsList({
                   </Button>
                 ))}
               </ButtonGroup>
-              <FieldTextStateless
-                isLabelHidden
-                shouldFitContainer={false}
-                id="requests-list-search"
-                placeholder="Search Requests"
-                onChange={event => onSearch(event.target.value)}
-                value={search}
-              />
+              <Search />
             </nav>
           </GridColumn>
         </Grid>
@@ -241,8 +233,6 @@ RequestsList.propTypes = {
   isLoaded: PropTypes.bool.isRequired,
   onChangeFilter: PropTypes.func.isRequired,
   onSort: PropTypes.func.isRequired,
-  onSearch: PropTypes.func.isRequired,
-  // onSelect: PropTypes.func.isRequired,
   page: PropTypes.number.isRequired,
   search: PropTypes.string.isRequired,
   sortKey: PropTypes.string.isRequired,

--- a/frontend/src/modules/requests/components/search/index.jsx
+++ b/frontend/src/modules/requests/components/search/index.jsx
@@ -1,0 +1,75 @@
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import Button from '@atlaskit/button';
+import CrossCircleIcon from '@atlaskit/icon/glyph/cross-circle';
+import Textfield from '@atlaskit/textfield';
+
+import * as styles from './styles.css';
+
+class Search extends React.Component {
+  constructor(props) {
+    super(props);
+    this.input = React.createRef();
+    this.state = {
+      value: '',
+    };
+  }
+
+  onSubmit = event => {
+    const { onSearch } = this.props;
+    event.preventDefault();
+
+    onSearch(this.input.current.value);
+  };
+
+  onChange = event => {
+    this.setState({
+      value: event.target.value,
+    });
+  };
+
+  onClear = event => {
+    const { onClear } = this.props;
+    event.preventDefault();
+    event.stopPropagation();
+
+    this.setState({
+      value: '',
+    });
+    onClear();
+  };
+
+  render() {
+    const { value } = this.state;
+
+    return (
+      <form className={styles.container} onSubmit={this.onSubmit}>
+        {value && (
+          <Button
+            appearance="subtle"
+            className={styles.clearButton}
+            onClick={this.onClear}
+            spacing="compact"
+          >
+            <CrossCircleIcon />
+          </Button>
+        )}
+        <Textfield
+          id="requests-list-search"
+          ref={this.input}
+          className={styles.input}
+          placeholder="Search Requests"
+          onChange={this.onChange}
+          value={value}
+        />
+      </form>
+    );
+  }
+}
+
+Search.propTypes = {
+  onClear: PropTypes.func.isRequired,
+  onSearch: PropTypes.func.isRequired,
+};
+
+export default Search;

--- a/frontend/src/modules/requests/components/search/styles.css
+++ b/frontend/src/modules/requests/components/search/styles.css
@@ -1,0 +1,19 @@
+.container {
+  margin-top: 0;
+  position: relative;
+}
+
+.clearButton {
+  position: absolute;
+  right: 0;
+  top: 50%;
+  margin-top: -11px;
+}
+
+.clearButton:hover {
+  background: transparent;
+}
+
+.input {
+  padding-right: 40px;
+}

--- a/frontend/src/modules/requests/containers/search.js
+++ b/frontend/src/modules/requests/containers/search.js
@@ -1,0 +1,22 @@
+import { connect } from 'react-redux';
+
+import { fetchRequests, clearSearch } from '../actions';
+import Search from '../components/search';
+import { requestsListSchema } from '../schemas';
+
+const mapStateToProps = state => ({
+  value: state.requests.viewState.search,
+});
+
+export default connect(mapStateToProps, {
+  onClear: clearSearch,
+  onSearch: name =>
+    fetchRequests(
+      { name },
+      {
+        url: `/api/v1/requests?name=${name}`,
+        schema: requestsListSchema,
+        search: name,
+      }
+    ),
+})(Search);

--- a/frontend/src/modules/requests/reducer.js
+++ b/frontend/src/modules/requests/reducer.js
@@ -1,5 +1,6 @@
 import { combineReducers } from 'redux';
 import get from 'lodash/get';
+import has from 'lodash/has';
 import mapKeys from 'lodash/mapKeys';
 import uniqueId from 'lodash/uniqueId';
 import union from 'lodash/union';
@@ -36,12 +37,6 @@ const viewState = (state = initialViewState, action = {}) => {
       return {
         ...state,
         ...action.payload,
-      };
-
-    case 'requests/search':
-      return {
-        ...state,
-        search: action.payload,
       };
 
     case 'requests/view/request':
@@ -98,7 +93,8 @@ const viewState = (state = initialViewState, action = {}) => {
     case 'requests/get':
       return {
         ...state,
-        page: action.payload.page,
+        search: get(action, 'meta.search', ''),
+        page: get(action, 'payload.page', state.page),
       };
 
     // If the result is empty it means there is exactly 100 items in the DB
@@ -106,7 +102,16 @@ const viewState = (state = initialViewState, action = {}) => {
     case 'requests/get/success':
       return {
         ...state,
-        page: action.payload.result.length > 0 ? state.page : state.page - 1,
+        page:
+          action.payload.result.length > 0 || has(action, 'meta.search')
+            ? state.page
+            : Math.max(state.page - 1, 1),
+      };
+
+    case 'requests/search/clear':
+      return {
+        ...state,
+        search: '',
       };
 
     default:

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1578,6 +1578,15 @@
     tslib "^1.8.0"
     uuid "^3.1.0"
 
+"@atlaskit/textfield@^0.1.6":
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/@atlaskit/textfield/-/textfield-0.1.6.tgz#4d606da205278fa45f75a603ce8da4195acc81b1"
+  integrity sha512-kkLuYJcahTyJXlF5BaUXFeIUV3hLE2kCcpVw2WTE+/q6RI8z1+9gpi0DkzVHx5yrRdt5Wb4OourfUxh9a+hRqA==
+  dependencies:
+    "@atlaskit/analytics-next" "^3.1.2"
+    "@atlaskit/theme" "^7.0.1"
+    "@babel/runtime" "^7.0.0"
+
 "@atlaskit/theme@^6.0.0", "@atlaskit/theme@^6.0.2", "@atlaskit/theme@^6.1.1", "@atlaskit/theme@^6.2.0", "@atlaskit/theme@^6.2.1":
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/@atlaskit/theme/-/theme-6.2.1.tgz#2d84a5b8dbd05c5d94064c0ab29e6f6a2f1ff415"


### PR DESCRIPTION
Search field is its own container now that makes requests to the API for a specific search so it is shown even if the result hasn't been cached on the client. Also fixed a bug where files were not deleting.