### PR TITLE
Add fallback of contentType for a fileType value

### DIFF
--- a/frontend/src/modules/requests/components/files-table/index.jsx
+++ b/frontend/src/modules/requests/components/files-table/index.jsx
@@ -97,7 +97,7 @@ function FilesTable({
         },
         {
           key: file.fileType,
-          content: file.fileType,
+          content: file.fileType || file.contentType || 'unknown',
         },
         {
           key: file.size,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Some file uploads lose their `filetype` value post upload. This PR has a fallback if there is no `filetype` it will either try and show the `content-type` or `unknown` if nothing exists on the metadata for the file.

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (non-breaking change with enhancements to documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](https://github.com/bcgov/OCWA/blob/master/CONTRIBUTING.md) doc
- [ ] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
