### PR TITLE
Fix buffer issue with file upload amounts > 13

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ocwa-frontend",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "src/index.js",
   "license": "MIT",
   "scripts": {

--- a/frontend/src/modules/files/components/file-uploader/index.jsx
+++ b/frontend/src/modules/files/components/file-uploader/index.jsx
@@ -67,7 +67,7 @@ class Uploader extends React.Component {
 
   render() {
     const { isDragging } = this.state;
-    const { data, fetchStatus, filesKey, uploadText } = this.props;
+    const { data, fetchStatus, filesKey, isUploading, uploadText } = this.props;
     const uploadButton = (
       <div
         className={cx(
@@ -75,12 +75,18 @@ class Uploader extends React.Component {
           'file-uploader-button-container'
         )}
       >
-        <Button className="file-uploader-button" iconBefore={<UploadIcon />}>
-          Upload Files
+        <Button
+          className="file-uploader-button"
+          disabled={isUploading}
+          isLoading={isUploading}
+          iconBefore={<UploadIcon />}
+        >
+          {isUploading ? 'Uploading...' : 'Upload Files'}
         </Button>
         <input
           multiple
           className={cx(styles.uploadInput, 'file-uploader-input')}
+          disabled={isUploading}
           type="file"
           onChange={this.onFileInputChange}
         />

--- a/frontend/src/modules/files/containers/file-uploader.js
+++ b/frontend/src/modules/files/containers/file-uploader.js
@@ -12,7 +12,8 @@ import { filesListSchema } from '../schemas';
 
 const mapStateToProps = (state, props) => {
   const { filesToDelete } = state.requests.viewState;
-  const ids = keys(state.files.entities)
+  const queuedFileIds = keys(state.files.entities);
+  const ids = queuedFileIds
     .map(id => {
       const file = get(state, `files.entities.${id}`, { id });
       // Unfortunately there is a temp ID and it can change, so we're
@@ -26,8 +27,11 @@ const mapStateToProps = (state, props) => {
     .map(d => d.id);
   const fileIds = get(props, ['data', props.filesKey], []);
   const data = union(fileIds, ids).filter(id => !filesToDelete.includes(id));
-  const uploadStatuses = values(state.files.entities);
-  const isUploading = uploadStatuses.some(isNumber);
+  const uploadStatuses = values(state.files.uploadStatus);
+  const isUploading =
+    uploadStatuses.length > 0 &&
+    (uploadStatuses.length !== queuedFileIds.length ||
+      uploadStatuses.some(isNumber));
   const fetchStatus = get(state, 'data.fetchStatus.dataTypes.files', 'idle');
 
   return {

--- a/frontend/src/modules/files/sagas.js
+++ b/frontend/src/modules/files/sagas.js
@@ -1,12 +1,12 @@
 import { all, call, fork, put, take } from 'redux-saga/effects';
-import { channel, delay, eventChannel, END } from 'redux-saga';
+import { buffers, channel, delay, eventChannel, END } from 'redux-saga';
 import { getToken } from '@src/services/auth';
 import difference from 'lodash/difference';
 import head from 'lodash/head';
-import { normalize } from 'normalizr';
+// import { normalize } from 'normalizr';
 import tus from 'tus-js-client';
 
-import { fileSchema } from './schemas';
+// import { fileSchema } from './schemas';
 import {
   uploadFileFailure,
   uploadFileProgress,
@@ -129,7 +129,7 @@ function* uploadDispatcher(chan) {
 // This saga is responsible for setting up the worker threads for uploading
 // before setting up a watcher for the upload action
 function* uploadFileWatcher() {
-  const chan = yield call(channel);
+  const chan = yield call(channel, buffers.expanding(10));
 
   for (let i = 0; i < 3; i += 1) {
     yield fork(uploadDispatcher, chan);


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->

# Description

Upload batches greater than 13 files was crashing the upload saga. Using the `buffers.expanding` method to scale up the buffers as needed fixes this issue. Also bump up the version to 1.1.0 and some other small fixes to the uploading UI.

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (non-breaking change with enhancements to documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](https://github.com/bcgov/OCWA/blob/master/CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
