### PR TITLE
Return duplicate request functionality

### DIFF
--- a/frontend/src/modules/requests/components/request-form/form.jsx
+++ b/frontend/src/modules/requests/components/request-form/form.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import ArrowRightCircleIcon from '@atlaskit/icon/glyph/arrow-right-circle';
 import Button, { ButtonGroup } from '@atlaskit/button';
 import { colors } from '@atlaskit/theme';
+import get from 'lodash/get';
 import TextField from '@atlaskit/textfield';
 import Form, {
   ErrorMessage,
@@ -12,17 +13,22 @@ import Form, {
   FormSection,
   HelperMessage,
 } from '@atlaskit/form';
+import pick from 'lodash/pick';
 import SectionMessage from '@atlaskit/section-message';
 import { uid } from 'react-uid';
 import { withRouter } from 'react-router-dom';
 
 import FormField from './field';
 import { requestFields } from '../../utils';
+import { RequestSchema } from '../../types';
 
-function NewRequestForm({ history, isCreating, onSubmit }) {
+function NewRequestForm({ data, history, isCreating, onSubmit }) {
+  // Grab the files if there is a duplicate getting passed through
+  const duplicateFiles = pick(data, ['files', 'supportingFiles']);
+
   return (
     <div id="request-form">
-      <Form onSubmit={onSubmit}>
+      <Form onSubmit={formData => onSubmit(formData, duplicateFiles)}>
         {({ formProps }) => (
           <form {...formProps}>
             <FormHeader
@@ -33,7 +39,7 @@ function NewRequestForm({ history, isCreating, onSubmit }) {
               isRequired
               name="name"
               label="Request Title"
-              defaultValue=""
+              defaultValue={get(data, 'name', '')}
               isDisabled={isCreating}
             >
               {({ fieldProps, error }) => (
@@ -60,7 +66,7 @@ function NewRequestForm({ history, isCreating, onSubmit }) {
                 <Field
                   key={uid(d)}
                   name={d.value}
-                  defaultValue=""
+                  defaultValue={get(data, d.value, '')}
                   label={d.name}
                   isDisabled={isCreating}
                   isRequired={d.isRequired}
@@ -119,11 +125,16 @@ function NewRequestForm({ history, isCreating, onSubmit }) {
 }
 
 NewRequestForm.propTypes = {
+  data: RequestSchema,
   history: PropTypes.shape({
     push: PropTypes.func.isRequired,
   }).isRequired,
   isCreating: PropTypes.bool.isRequired,
   onSubmit: PropTypes.func.isRequired,
+};
+
+NewRequestForm.defaultProps = {
+  data: {},
 };
 
 export default withRouter(NewRequestForm);

--- a/frontend/src/modules/requests/components/request-form/index.jsx
+++ b/frontend/src/modules/requests/components/request-form/index.jsx
@@ -6,20 +6,24 @@ import Form from './form';
 import * as styles from './styles.css';
 
 class NewRequestDialog extends React.PureComponent {
-  onSubmit = data => {
+  onSubmit = (data, files) => {
     const { history, sendAction } = this.props;
-    sendAction('onCreate', data, { history });
+    sendAction('onCreate', data, { history, files });
   };
 
   render() {
-    const { isCreating } = this.props;
+    const { isCreating, location } = this.props;
 
     return (
       <Page>
         <div id="request-form-container" className={styles.container}>
           <Grid>
             <GridColumn medium={12}>
-              <Form isCreating={isCreating} onSubmit={this.onSubmit} />
+              <Form
+                data={location.state || {}}
+                isCreating={isCreating}
+                onSubmit={this.onSubmit}
+              />
             </GridColumn>
           </Grid>
         </div>
@@ -29,7 +33,11 @@ class NewRequestDialog extends React.PureComponent {
 }
 
 NewRequestDialog.propTypes = {
+  history: PropTypes.object.isRequired,
   isCreating: PropTypes.bool.isRequired,
+  location: PropTypes.shape({
+    state: PropTypes.object,
+  }).isRequired,
   sendAction: PropTypes.func.isRequired,
 };
 

--- a/frontend/src/modules/requests/components/request-menu/index.jsx
+++ b/frontend/src/modules/requests/components/request-menu/index.jsx
@@ -5,6 +5,7 @@ import DropdownMenu, {
   DropdownItem,
 } from '@atlaskit/dropdown-menu';
 
+import { duplicateRequest } from '../../utils';
 import { RequestSchema } from '../../types';
 
 function RequestMenu({
@@ -46,6 +47,13 @@ function RequestMenu({
               Delete
             </DropdownItem>
           </React.Fragment>
+        )}
+        {data.state === 4 && (
+          <DropdownItem
+            onClick={() => history.push('/new', duplicateRequest(data))}
+          >
+            Duplicate
+          </DropdownItem>
         )}
       </DropdownItemGroup>
     </DropdownMenu>

--- a/frontend/src/modules/requests/components/request/__tests__/sidebar.test.jsx
+++ b/frontend/src/modules/requests/components/request/__tests__/sidebar.test.jsx
@@ -18,7 +18,6 @@ const defaultProps = {
   isEditing: false,
   onCancel: () => null,
   onDelete: () => null,
-  onDuplicate: () => null,
   onEdit: () => null,
   onSubmit: () => null,
   onWithdraw: () => null,
@@ -206,19 +205,6 @@ describe('components/request/sidebar', () => {
       );
       const button = wrapper.find('button#request-sidebar-submit-button');
       expect(button.prop('disabled')).toBeTruthy();
-    });
-
-    it('should handle the duplicate button', () => {
-      const onDuplicate = jest.fn();
-      const data = {
-        ...defaultData,
-        state: 6,
-      };
-      const wrapper = renderer(
-        <Sidebar {...defaultProps} onDuplicate={onDuplicate} data={data} />
-      );
-      wrapper.find('button#request-sidebar-duplicate-button').simulate('click');
-      expect(onDuplicate).toHaveBeenCalledWith(data);
     });
   });
 });

--- a/frontend/src/modules/requests/components/request/details.jsx
+++ b/frontend/src/modules/requests/components/request/details.jsx
@@ -4,6 +4,7 @@ import isEmpty from 'lodash/isEmpty';
 import Files from '@src/modules/files/containers/files';
 import FileUploader from '@src/modules/files/containers/file-uploader';
 import get from 'lodash/get';
+import merge from 'lodash/merge';
 import { Prompt } from 'react-router-dom';
 import { uid } from 'react-uid';
 
@@ -12,7 +13,7 @@ import { RequestSchema } from '../../types';
 import { requestFields } from '../../utils';
 import * as styles from './styles.css';
 
-function RequestDetails({ data, isEditing, onSave }) {
+function RequestDetails({ data, duplicateFiles, isEditing, onSave }) {
   const files = get(data, 'files', []);
   const supportingFiles = get(data, 'supportingFiles', []);
   const requestDetails = requestFields.map(d => ({
@@ -22,6 +23,8 @@ function RequestDetails({ data, isEditing, onSave }) {
     key: d.value,
     isRequired: d.isRequired,
   }));
+  console.log(duplicateFiles);
+  const uploadData = merge({}, data, duplicateFiles);
 
   if (isEmpty(data)) {
     return 'Loading...';
@@ -60,7 +63,7 @@ function RequestDetails({ data, isEditing, onSave }) {
           )}
           {isEditing && (
             <FileUploader
-              data={data}
+              data={uploadData}
               filesKey="files"
               uploadText="Upload files you wish to request for output"
             />
@@ -76,7 +79,7 @@ function RequestDetails({ data, isEditing, onSave }) {
           {!isEditing && <Files showDownloadButton ids={supportingFiles} />}
           {isEditing && (
             <FileUploader
-              data={data}
+              data={uploadData}
               filesKey="supportingFiles"
               uploadText="Upload any files to help support your request"
             />
@@ -89,12 +92,20 @@ function RequestDetails({ data, isEditing, onSave }) {
 
 RequestDetails.propTypes = {
   data: RequestSchema,
+  duplicateFiles: PropTypes.shape({
+    files: PropTypes.arrayOf(PropTypes.string),
+    supportingFiles: PropTypes.arrayOf(PropTypes.string),
+  }),
   isEditing: PropTypes.bool.isRequired,
   onSave: PropTypes.func.isRequired,
 };
 
 RequestDetails.defaultProps = {
   data: {},
+  duplicateFiles: {
+    files: [],
+    supportingFiles: [],
+  },
 };
 
 export default RequestDetails;

--- a/frontend/src/modules/requests/components/request/details.jsx
+++ b/frontend/src/modules/requests/components/request/details.jsx
@@ -23,7 +23,6 @@ function RequestDetails({ data, duplicateFiles, isEditing, onSave }) {
     key: d.value,
     isRequired: d.isRequired,
   }));
-  console.log(duplicateFiles);
   const uploadData = merge({}, data, duplicateFiles);
 
   if (isEmpty(data)) {

--- a/frontend/src/modules/requests/components/request/index.jsx
+++ b/frontend/src/modules/requests/components/request/index.jsx
@@ -5,6 +5,7 @@ import Date from '@src/components/date';
 import get from 'lodash/get';
 import isEmpty from 'lodash/isEmpty';
 import { NavLink, Route, Switch } from 'react-router-dom';
+import merge from 'lodash/merge';
 import Lozenge from '@atlaskit/lozenge';
 import Discussion from '@src/modules/discussion/containers/discussion';
 import Spinner from '@atlaskit/spinner';
@@ -44,14 +45,23 @@ class Request extends React.Component {
   };
 
   onSave = updatedData => {
-    const { data, onSave } = this.props;
+    const { data, location, onSave } = this.props;
+    const duplicateFiles = get(location, 'state.duplicateFiles');
 
-    onSave({ ...data, ...updatedData }, { id: data._id });
+    onSave(merge({}, data, updatedData, duplicateFiles), { id: data._id });
   };
 
   render() {
-    const { data, isLoaded, isOutputChecker, updatedAt, match } = this.props;
+    const {
+      data,
+      isLoaded,
+      isOutputChecker,
+      location,
+      updatedAt,
+      match,
+    } = this.props;
     const { isEditing } = this.state;
+    const duplicateFiles = get(location, 'state.duplicateFiles');
     const title = data.name || 'Loading...';
 
     if (!isLoaded && isEmpty(data)) {
@@ -120,6 +130,7 @@ class Request extends React.Component {
                     render={() => (
                       <Details
                         data={data}
+                        duplicateFiles={duplicateFiles}
                         isEditing={isEditing}
                         onSave={this.onSave}
                       />
@@ -158,6 +169,14 @@ Request.propTypes = {
   data: RequestSchema.isRequired,
   isOutputChecker: PropTypes.bool.isRequired,
   isLoaded: PropTypes.bool.isRequired,
+  location: PropTypes.shape({
+    state: PropTypes.shape({
+      duplicateFiles: PropTypes.shape({
+        files: PropTypes.arrayOf(PropTypes.string),
+        supportingFiles: PropTypes.arrayOf(PropTypes.string),
+      }),
+    }),
+  }).isRequired,
   updatedAt: PropTypes.string.isRequired,
   match: PropTypes.shape({
     url: PropTypes.string.isRequired,

--- a/frontend/src/modules/requests/components/request/index.jsx
+++ b/frontend/src/modules/requests/components/request/index.jsx
@@ -45,23 +45,21 @@ class Request extends React.Component {
   };
 
   onSave = updatedData => {
-    const { data, location, onSave } = this.props;
-    const duplicateFiles = get(location, 'state.duplicateFiles');
+    const { data, onSave } = this.props;
 
-    onSave(merge({}, data, updatedData, duplicateFiles), { id: data._id });
+    onSave(merge({}, data, updatedData), { id: data._id });
   };
 
   render() {
     const {
       data,
+      duplicateFiles,
       isLoaded,
       isOutputChecker,
-      location,
       updatedAt,
       match,
     } = this.props;
     const { isEditing } = this.state;
-    const duplicateFiles = get(location, 'state.duplicateFiles');
     const title = data.name || 'Loading...';
 
     if (!isLoaded && isEmpty(data)) {
@@ -167,14 +165,15 @@ class Request extends React.Component {
 
 Request.propTypes = {
   data: RequestSchema.isRequired,
+  duplicateFiles: PropTypes.shape({
+    files: PropTypes.arrayOf(PropTypes.string),
+    supportingFiles: PropTypes.arrayOf(PropTypes.string),
+  }).isRequired,
   isOutputChecker: PropTypes.bool.isRequired,
   isLoaded: PropTypes.bool.isRequired,
   location: PropTypes.shape({
     state: PropTypes.shape({
-      duplicateFiles: PropTypes.shape({
-        files: PropTypes.arrayOf(PropTypes.string),
-        supportingFiles: PropTypes.arrayOf(PropTypes.string),
-      }),
+      isEditing: PropTypes.bool,
     }),
   }).isRequired,
   updatedAt: PropTypes.string.isRequired,

--- a/frontend/src/modules/requests/components/request/sidebar.jsx
+++ b/frontend/src/modules/requests/components/request/sidebar.jsx
@@ -11,7 +11,18 @@ import SignInIcon from '@atlaskit/icon/glyph/sign-in';
 import SignOutIcon from '@atlaskit/icon/glyph/sign-out';
 import TrashIcon from '@atlaskit/icon/glyph/trash';
 
+import { duplicateRequest } from '../../utils';
 import { RequestSchema } from '../../types';
+
+const omitProps = [
+  '_id',
+  'state',
+  'reviewers',
+  'author',
+  'chronology',
+  'fileStatus',
+  'topic',
+];
 
 function RequestSidebar({
   data,
@@ -20,7 +31,6 @@ function RequestSidebar({
   history,
   onCancel,
   onDelete,
-  onDuplicate,
   onEdit,
   onSubmit,
   onWithdraw,
@@ -136,7 +146,7 @@ function RequestSidebar({
           id="request-sidebar-duplicate-button"
           iconBefore={<CopyIcon />}
           isDisabled={isSaving}
-          onClick={() => onDuplicate(data)}
+          onClick={() => history.push('/new', duplicateRequest(data))}
         >
           Duplicate Request
         </Button>
@@ -154,7 +164,6 @@ RequestSidebar.propTypes = {
   isSaving: PropTypes.bool.isRequired,
   onCancel: PropTypes.func.isRequired,
   onDelete: PropTypes.func.isRequired,
-  onDuplicate: PropTypes.func.isRequired,
   onEdit: PropTypes.func.isRequired,
   onSubmit: PropTypes.func.isRequired,
   onWithdraw: PropTypes.func.isRequired,

--- a/frontend/src/modules/requests/containers/request.js
+++ b/frontend/src/modules/requests/containers/request.js
@@ -30,6 +30,7 @@ const mapStateToProps = (state, props) => {
 
   return {
     data,
+    duplicateFiles: get(state, 'requests.viewState.filesToDuplicate'),
     isOutputChecker: state.app.auth.user.groups.includes('/oc'),
     updatedAt,
     fetchStatus: get(state, `data.fetchStatus.entities.requests.${requestId}`),

--- a/frontend/src/modules/requests/reducer.js
+++ b/frontend/src/modules/requests/reducer.js
@@ -25,12 +25,17 @@ const duplicateValueMapper = (value, key) => {
   return value;
 };
 
+const filesToDuplicate = {
+  files: [],
+  supportingFiles: [],
+};
 const initialViewState = {
   currentRequestId: null,
   currentNewRequestStep: 0,
   duplicateRequest: undefined,
   filter: null,
   filesToDelete: [],
+  filesToDuplicate,
   showMyRequestsOnly: false,
   sortKey: 'state',
   sortOrder: 'DESC',
@@ -81,9 +86,16 @@ const viewState = (state = initialViewState, action = {}) => {
       return {
         ...state,
         filesToDelete: [],
+        filesToDuplicate,
         currentRequestId: null,
         currentNewRequestStep: 0,
         duplicateRequest: undefined,
+      };
+
+    case 'request/duplicate/files':
+      return {
+        ...state,
+        filesToDuplicate: action.payload,
       };
 
     case 'requests/change-step':
@@ -96,6 +108,7 @@ const viewState = (state = initialViewState, action = {}) => {
       return {
         ...state,
         filesToDelete: [],
+        filesToDuplicate,
         currentRequestId: action.meta.quitEditing
           ? null
           : state.currentRequestId,

--- a/frontend/src/modules/requests/sagas.js
+++ b/frontend/src/modules/requests/sagas.js
@@ -17,7 +17,7 @@ function* onSaveRequest(action) {
   }
 }
 
-function onCreateRequest(action) {
+function* onCreateRequest(action) {
   const id = get(action, 'payload.result.result');
   const duplicateFiles = get(action, 'meta.files', {});
 
@@ -25,6 +25,10 @@ function onCreateRequest(action) {
     action.meta.history.push(`/requests/${id}`, {
       isEditing: true,
       duplicateFiles,
+    });
+    yield put({
+      type: 'request/duplicate/files',
+      payload: duplicateFiles,
     });
   }
 }
@@ -39,14 +43,20 @@ function* onFinishEditing(action) {
   const request = yield select(state =>
     get(state, `data.entities.requests.${id}`, {})
   );
-  const { filesToDelete } = yield select(state => state.requests.viewState);
+  const { filesToDelete, filesToDuplicate } = yield select(
+    state => state.requests.viewState
+  );
   const deletedFilesHandler = fileId => !filesToDelete.includes(fileId);
   const payload = {
     ...request,
-    files: union(request.files, files).filter(deletedFilesHandler),
-    supportingFiles: union(request.supportingFiles, supportingFiles).filter(
+    files: union(request.files, files, filesToDuplicate.files).filter(
       deletedFilesHandler
     ),
+    supportingFiles: union(
+      request.supportingFiles,
+      supportingFiles,
+      filesToDuplicate.supportingFiles
+    ).filter(deletedFilesHandler),
   };
   const meta = { id };
 

--- a/frontend/src/modules/requests/sagas.js
+++ b/frontend/src/modules/requests/sagas.js
@@ -19,9 +19,13 @@ function* onSaveRequest(action) {
 
 function onCreateRequest(action) {
   const id = get(action, 'payload.result.result');
+  const duplicateFiles = get(action, 'meta.files', {});
 
   if (id) {
-    action.meta.history.push(`/requests/${id}`, { isEditing: true });
+    action.meta.history.push(`/requests/${id}`, {
+      isEditing: true,
+      duplicateFiles,
+    });
   }
 }
 

--- a/frontend/src/modules/requests/utils.js
+++ b/frontend/src/modules/requests/utils.js
@@ -1,4 +1,8 @@
 import { colors } from '@atlaskit/theme';
+import flow from 'lodash/flow';
+import isNil from 'lodash/isNil';
+import pick from 'lodash/pick';
+import mapValues from 'lodash/mapValues';
 
 // Request fields. Useful for forms/edit
 export const requestFields = [
@@ -65,7 +69,20 @@ export const getRequestStateColor = (value = 0) => {
   }
 };
 
+// Tidy up a request for duplication
+export const duplicateRequest = data => {
+  const formConfigKeys = requestFields.map(d => d.value);
+  const keys = [...formConfigKeys, 'name', 'files', 'supportingFiles'];
+  const cleaner = flow([
+    d => pick(d, keys),
+    d => mapValues(d, v => (isNil(v) ? '' : v)),
+  ]);
+
+  return cleaner({ ...data, name: `${data.name} Duplicate` });
+};
+
 export default {
+  duplicateRequest,
   getRequestStateColor,
   requestFields,
   phoneNumberRegex,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Switching to the new form workflow broke the Duplicate Request functionality, this PR returns that functionality by duplicating the form field values and adding `.... Duplicate` to the end of the name, and after the request is duplicated via the form it caches the file ID's so they can be attached to the new request if the user wishes or removed in the following edit screen after a success response.

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (non-breaking change with enhancements to documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](https://github.com/bcgov/OCWA/blob/master/CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
