### PR TITLE
Add a basic localization tool for import/export language

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,8 @@
     "start:prod": "cross-env NODE_ENV=production node server/index.js",
     "build": "cross-env NODE_ENV=production webpack --config webpack.prod.js",
     "lint": "eslint src/index.js",
-    "test": "jest --coverage"
+    "test": "jest --coverage",
+    "test:watch": "jest --watch"
   },
   "devDependencies": {
     "@babel/cli": "^7.4.3",

--- a/frontend/src/modules/download/components/requests/index.jsx
+++ b/frontend/src/modules/download/components/requests/index.jsx
@@ -7,7 +7,7 @@ import last from 'lodash/last';
 import { Link } from 'react-router-dom';
 import Page, { Grid, GridColumn } from '@atlaskit/page';
 import { RequestSchema } from '@src/modules/requests/types';
-import { zone } from '@src/services/config';
+import { _e } from '@src/utils';
 
 import Downloads from '../../containers/downloads';
 import renderEmpty from './empty';
@@ -29,7 +29,6 @@ const header = {
 };
 
 function Requests({ data, isLoading, onSort, sortKey, sortOrder }) {
-  const zoneString = zone === 'internal' ? 'import' : 'export';
   const rows = data.map(d => {
     const format = 'MMM Do, YYYY';
     const submittedOn = head(d.chronology).timestamp;
@@ -76,7 +75,9 @@ function Requests({ data, isLoading, onSort, sortKey, sortOrder }) {
             </div>
             <h1>Approved Requests</h1>
             <p>
-              {`The ${zoneString} requests listed below are available for download.`}
+              {_e(
+                'The {download} requests listed below are available for download.'
+              )}
             </p>
           </header>
         </GridColumn>

--- a/frontend/src/modules/requests/components/request-form/index.jsx
+++ b/frontend/src/modules/requests/components/request-form/index.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import Page, { Grid, GridColumn } from '@atlaskit/page';
 import SectionMessage from '@atlaskit/section-message';
 import Select from '@atlaskit/select';
+import { _e } from '@src/utils';
 
 import Form from './form';
 import * as styles from './styles.css';
@@ -19,8 +20,8 @@ function NewRequestForm({
 }) {
   const data = location.state || {};
   const exportTypeOptions = [
-    { label: 'Data Export', value: 'data' },
-    { label: 'Code Export', value: 'code' },
+    { label: _e('Data {Request}'), value: 'data' },
+    { label: _e('Code {Request}'), value: 'code' },
   ];
   const defaultState = data.exportType
     ? exportTypeOptions.find(d => d.value === data.exportType)
@@ -55,11 +56,11 @@ function NewRequestForm({
               <div className={styles.exportTypeSelect}>
                 <SectionMessage
                   appearance="info"
-                  title="Select Data Export Type"
+                  title={_e('Select Data {Request} Type')}
                 >
                   <Select
                     options={exportTypeOptions}
-                    placeholder="Choose an Export Type"
+                    placeholder={_e('Choose an {Request} Type')}
                     id="request-form-exportTypeSelect"
                     defaultValue={exportType}
                     onChange={value => setExportType(value)}
@@ -68,8 +69,9 @@ function NewRequestForm({
               </div>
             )}
             {exportType.value === 'data' && <Form {...formProps} />}
-            {exportType.value === 'code' &&
-              codeExportEnabled && <Form {...formProps} />}
+            {exportType.value === 'code' && codeExportEnabled && (
+              <Form {...formProps} />
+            )}
           </GridColumn>
         </Grid>
       </div>

--- a/frontend/src/modules/requests/components/request/details.jsx
+++ b/frontend/src/modules/requests/components/request/details.jsx
@@ -8,6 +8,7 @@ import get from 'lodash/get';
 import merge from 'lodash/merge';
 import { Prompt } from 'react-router-dom';
 import { uid } from 'react-uid';
+import { _e } from '@src/utils';
 
 import EditField from './edit-field';
 import { RequestSchema } from '../../types';
@@ -67,7 +68,7 @@ function RequestDetails({
         <React.Fragment>
           <div id="request-export-files" className={styles.section}>
             <div className={styles.sectionHeader}>
-              Output Files
+              {_e('{Files} Files')}
               {isEditing && ' (Drop files here to upload)'}
             </div>
             <div className={styles.sectionContent}>

--- a/frontend/src/modules/requests/components/request/index.jsx
+++ b/frontend/src/modules/requests/components/request/index.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import SectionMessage from '@atlaskit/section-message';
 import ExportTypeIcon from '@src/components/export-type-icon';
 import Page, { Grid, GridColumn } from '@atlaskit/page';
+import CalendarIcon from '@atlaskit/icon/glyph/calendar';
 import Date from '@src/components/date';
 import get from 'lodash/get';
 import { NavLink, Route, Switch } from 'react-router-dom';
@@ -11,11 +12,13 @@ import Lozenge from '@atlaskit/lozenge';
 import Discussion from '@src/modules/discussion/containers/discussion';
 import Spinner from '@atlaskit/spinner';
 import Title from '@src/components/title';
+import { colors } from '@atlaskit/theme';
 
 import InfoIcon from '@atlaskit/icon/glyph/info';
 import CommentIcon from '@atlaskit/icon/glyph/comment';
 
 import Details from './details';
+import RequestType from './request-type';
 import StateLabel from '../state-label';
 import Sidebar from '../../containers/sidebar';
 import { RequestSchema } from '../../types';
@@ -82,6 +85,10 @@ class Request extends React.Component {
                   <span>{title}</span>
                 </h1>
                 <p id="request-header-details">
+                  <RequestType />
+                  <span>
+                    <CalendarIcon size="small" primaryColor={colors.DN300} />
+                  </span>
                   {'Updated at '}
                   <Date value={updatedAt} format="HH:MMa on MMMM Do, YYYY" />
                   {isEditing && (

--- a/frontend/src/modules/requests/components/request/request-type.jsx
+++ b/frontend/src/modules/requests/components/request/request-type.jsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import ArrowDownCircleIcon from '@atlaskit/icon/glyph/arrow-down-circle';
+import ArrowUpCircleIcon from '@atlaskit/icon/glyph/arrow-up-circle';
+import { zone } from '@src/services/config';
+import { colors } from '@atlaskit/theme';
+import { _e } from '@src/utils';
+
+function RequestType() {
+  const icon =
+    zone === 'internal' ? (
+      <ArrowUpCircleIcon size="small" primaryColor={colors.DN300} />
+    ) : (
+      <ArrowDownCircleIcon size="small" primaryColor={colors.DN300} />
+    );
+  return (
+    <strong>
+      {icon} {_e('{Request} Request')}
+    </strong>
+  );
+}
+
+export default RequestType;

--- a/frontend/src/modules/requests/components/request/sidebar.jsx
+++ b/frontend/src/modules/requests/components/request/sidebar.jsx
@@ -7,6 +7,7 @@ import inRange from 'lodash/inRange';
 import startCase from 'lodash/startCase';
 import { withRouter } from 'react-router-dom';
 import { uid } from 'react-uid';
+import { _e } from '@src/utils';
 // Icons
 import CopyIcon from '@atlaskit/icon/glyph/copy';
 import CrossIcon from '@atlaskit/icon/glyph/cross';
@@ -82,7 +83,7 @@ function RequestSidebar({
     <aside id="request-sidebar">
       <h6>Requester</h6>
       <div id="request-author">{data.author}</div>
-      <h6>Export Type</h6>
+      <h6>{_e('{Request} Type')}</h6>
       <div id="request-exportType">
         <ExportTypeIcon exportType={data.exportType} />
         <span id="request-exportTypeText" className={styles.exportTypeText}>
@@ -91,39 +92,40 @@ function RequestSidebar({
       </div>
       <h6>Output Checker</h6>
       <div id="request-reviewers">
-        {data.reviewers.map(d => <p key={uid(d)}>{d}</p>)}
+        {data.reviewers.map(d => (
+          <p key={uid(d)}>{d}</p>
+        ))}
       </div>
       {data.reviewers.length <= 0 && (
         <p id="request-reviewers-empty">No reviewer has been assigned</p>
       )}
       <h6>Actions</h6>
-      {data.state >= 2 &&
-        data.state < 4 && (
-          <React.Fragment>
-            <div>
-              <Button
-                appearance="link"
-                id="request-sidebar-withdraw-button"
-                isDisabled={isSaving}
-                iconBefore={<SignOutIcon />}
-                onClick={withdrawHandler}
-              >
-                Edit Request
-              </Button>
-            </div>
-            <div>
-              <Button
-                appearance="link"
-                id="request-sidebar-cancel-button"
-                iconBefore={<CrossIcon />}
-                isDisabled={isSaving}
-                onClick={() => onCancel(data._id)}
-              >
-                Cancel Request
-              </Button>
-            </div>
-          </React.Fragment>
-        )}
+      {data.state >= 2 && data.state < 4 && (
+        <React.Fragment>
+          <div>
+            <Button
+              appearance="link"
+              id="request-sidebar-withdraw-button"
+              isDisabled={isSaving}
+              iconBefore={<SignOutIcon />}
+              onClick={withdrawHandler}
+            >
+              Edit Request
+            </Button>
+          </div>
+          <div>
+            <Button
+              appearance="link"
+              id="request-sidebar-cancel-button"
+              iconBefore={<CrossIcon />}
+              isDisabled={isSaving}
+              onClick={() => onCancel(data._id)}
+            >
+              Cancel Request
+            </Button>
+          </div>
+        </React.Fragment>
+      )}
       {data.state < 2 && (
         <React.Fragment>
           <div>

--- a/frontend/src/modules/requests/utils.js
+++ b/frontend/src/modules/requests/utils.js
@@ -3,6 +3,7 @@ import flow from 'lodash/flow';
 import isNil from 'lodash/isNil';
 import pick from 'lodash/pick';
 import mapValues from 'lodash/mapValues';
+import { _e, getZoneString } from '@src/utils';
 
 // Form content
 export const formText = {
@@ -68,10 +69,15 @@ export const requestFields = [
     type: 'textarea',
     exportType: 'code',
     isRequired: true,
-    helperText: 'Describe any details about the code you wish to export here',
+    helperText: _e(
+      'Describe any details about the code you wish to {request} here'
+    ),
   },
   {
-    name: 'Repository of code to export',
+    name: getZoneString({
+      internal: 'Repository of code to export',
+      external: 'Internal repository to send approved results',
+    }),
     value: 'repository',
     type: 'url',
     exportType: 'code',
@@ -79,7 +85,7 @@ export const requestFields = [
     helperText: 'Write out the full URL of the repository',
   },
   {
-    name: 'Branch of code to export',
+    name: _e('Branch of code to {request}'),
     value: 'branch',
     type: 'text',
     exportType: 'code',
@@ -88,7 +94,10 @@ export const requestFields = [
       'Write out the branch name in the repository the Output Checker should review',
   },
   {
-    name: 'External repository to send approved results',
+    name: getZoneString({
+      internal: 'Repository of code to import',
+      external: 'External repository to send approved results',
+    }),
     value: 'externalRepository',
     type: 'url',
     exportType: 'code',

--- a/frontend/src/services/config.js
+++ b/frontend/src/services/config.js
@@ -9,6 +9,7 @@ export const ocGroup = OC_GROUP;
 export const exporterMode = EXPORTER_MODE; // Can be (undefined || 'export') or 'download'
 export const codeExportEnabled = CODE_EXPORT_ENABLED; // Can be (undefined || 'export') or 'download'
 export const zone = ZONE;
+export const getZone = () => ZONE;
 
 export default {
   codeExportEnabled,
@@ -21,4 +22,5 @@ export default {
   exporterMode,
   socketHost,
   zone,
+  getZone,
 };

--- a/frontend/src/utils/__tests__/utils.test.js
+++ b/frontend/src/utils/__tests__/utils.test.js
@@ -1,0 +1,74 @@
+import * as utils from '../';
+
+describe('App utils', () => {
+  describe('getZoneString', () => {
+    const config = {
+      internal: 'Internal String',
+      external: 'External String',
+    };
+
+    describe('default functionality', () => {
+      expect(utils.getZoneString()).toEqual('');
+      expect(
+        utils.getZoneString({
+          wrong: 'key',
+        })
+      ).toEqual('');
+    });
+
+    describe('internal', () => {
+      it('should work internally', () => {
+        expect(utils.getZoneString(config)).toEqual(config.internal);
+      });
+    });
+
+    describe('external', () => {
+      beforeEach(() => {
+        global.ZONE = 'external';
+      });
+      afterEach(() => {
+        global.ZONE = 'internal';
+      });
+      it('should work externally', () => {
+        expect(utils.getZoneString(config)).toEqual(config.external);
+      });
+    });
+  });
+
+  describe('_e', () => {
+    describe('formatting', () => {
+      it('retain first letter case', () => {
+        expect(utils._e('This is an {Request}')).toEqual('This is an Export');
+      });
+
+      it('should work if incorrect template variable is used', () => {
+        expect(utils._e('This is {wrong}')).toEqual('This is {wrong}');
+      });
+
+      it('should work if no template tag is present', () => {
+        expect(utils._e('This is empty')).toEqual('This is empty');
+      });
+    });
+
+    describe('internal strings', () => {
+      it('should render a template', () => {
+        expect(utils._e('This is an {request}')).toEqual('This is an export');
+        expect(utils._e('This is an {download}')).toEqual('This is an import');
+      });
+    });
+
+    describe('external strings', () => {
+      beforeEach(() => {
+        global.ZONE = 'external';
+      });
+      afterEach(() => {
+        global.ZONE = 'internal';
+      });
+
+      it('should render a template', () => {
+        expect(utils._e('This is an {request}')).toEqual('This is an import');
+        expect(utils._e('This is an {download}')).toEqual('This is an export');
+      });
+    });
+  });
+});

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -1,2 +1,45 @@
-// Add any global utils here
-export default {};
+import get from 'lodash/get';
+import template from 'lodash/template';
+import { getZone } from '@src/services/config';
+
+export const getZoneString = options => {
+  const zone = getZone();
+  return get(options, zone, '');
+};
+
+const interpolate = /{([\s\S]+?)}/g;
+
+const strings = {
+  internal: {
+    Files: 'Output',
+    request: 'export',
+    Request: 'Export',
+    download: 'import',
+    Download: 'Import',
+  },
+  external: {
+    Files: 'Input',
+    request: 'import',
+    Request: 'Import',
+    download: 'export',
+    Download: 'Export',
+  },
+};
+
+export const _e = str => {
+  const zone = getZone();
+  const data = strings[zone];
+  const keys = Object.keys(data);
+  const compiled = template(str, {
+    interpolate,
+  });
+
+  if (!keys.find(k => str.search(`{${k}}`) > -1)) return str;
+
+  return compiled(data);
+};
+
+export default {
+  _e,
+  getZoneString,
+};

--- a/frontend/tests/globals.js
+++ b/frontend/tests/globals.js
@@ -1,1 +1,12 @@
 global.confirm = jest.fn(() => true);
+global.FILES_API_HOST = 'http://localhost:3000';
+global.SOCKET_HOST = 'ws://localhost:3000';
+global.COMMIT = '98sf9842rse8238ew9r8we9f89';
+global.ID_FIELD = 'preferred_username';
+global.EXPORTER_GROUP = '/exporter';
+global.OC_GROUP = '/oc';
+global.EXPORTER_MODE = 'export';
+global.CODE_EXPORT_ENABLED = true;
+global.REPOSITORY_HOST = 'https://example.com/shares/';
+global.ZONE = 'internal';
+global.VERSION = '1.1.1';


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->

# Description

Adds a new `_e` helper function which will output a localized string depending on the zone (internal or external). Original ticket is PROOF-2247.

Example (internal)
`_e('This is an {request}')`

Outputs `This is an export`

Currently supported strings

- Files: 'Output' or 'Input'
- request: 'export' or 'import'
- Request: 'Export' or 'Import'
- download: 'import' or 'export'
- Download: 'Import' or 'Export'

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation (non-breaking change with enhancements to documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](https://github.com/bcgov/OCWA/blob/master/CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
