### PR TITLE
Removed cached 'isEditing' state on history stack

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ocwa-frontend",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/frontend/src/modules/files/components/files-table/index.jsx
+++ b/frontend/src/modules/files/components/files-table/index.jsx
@@ -229,7 +229,6 @@ FilesTable.propTypes = {
   isLoading: PropTypes.bool.isRequired,
   isLoaded: PropTypes.bool.isRequired,
   isFailed: PropTypes.bool.isRequired,
-  requestId: PropTypes.string.isRequired,
   sendAction: PropTypes.func.isRequired,
   showDownloadButton: PropTypes.bool,
   showRemoveButton: PropTypes.bool,

--- a/frontend/src/modules/requests/components/request/details.jsx
+++ b/frontend/src/modules/requests/components/request/details.jsx
@@ -19,6 +19,7 @@ import * as styles from './styles.css';
 function RequestDetails({
   data,
   duplicateFiles,
+  id,
   isEditing,
   isLoading,
   onSave,
@@ -30,7 +31,7 @@ function RequestDetails({
     .filter(
       d =>
         (d.exportType === 'all' || d.exportType === exportType) &&
-        (d.zone === 'all' || d.zone === zone),
+        (d.zone === 'all' || d.zone === zone)
     )
     .map(d => ({
       name: d.name,
@@ -80,7 +81,7 @@ function RequestDetails({
               {!isEditing && (
                 <Files
                   showDownloadButton
-                  id={data._id}
+                  id={id}
                   ids={files}
                   fileStatus={data.fileStatus}
                 />
@@ -101,7 +102,7 @@ function RequestDetails({
             </div>
             <div className={styles.sectionContent}>
               {!isEditing && (
-                <Files showDownloadButton id={data._id} ids={supportingFiles} />
+                <Files showDownloadButton id={id} ids={supportingFiles} />
               )}
               {isEditing && (
                 <FileUploader
@@ -124,6 +125,7 @@ RequestDetails.propTypes = {
     files: PropTypes.arrayOf(PropTypes.string),
     supportingFiles: PropTypes.arrayOf(PropTypes.string),
   }),
+  id: PropTypes.string.isRequired,
   isEditing: PropTypes.bool.isRequired,
   isLoading: PropTypes.bool.isRequired,
   onSave: PropTypes.func.isRequired,

--- a/frontend/src/modules/requests/components/request/index.jsx
+++ b/frontend/src/modules/requests/components/request/index.jsx
@@ -49,9 +49,20 @@ class Request extends React.Component {
   }
 
   onEdit = () => {
-    this.setState(state => ({
-      isEditing: !state.isEditing,
-    }));
+    const { isEditing } = this.state;
+    const { history, location } = this.props;
+
+    // Always turn off the cached editing value after editing
+    this.setState(
+      state => ({
+        isEditing: !state.isEditing,
+      }),
+      () => {
+        if (isEditing) {
+          history.replace(location.pathname, { isEditing: false });
+        }
+      }
+    );
   };
 
   onSave = updatedData => {
@@ -206,6 +217,7 @@ class Request extends React.Component {
                       <Details
                         data={data}
                         duplicateFiles={duplicateFiles}
+                        id={match.params.requestId}
                         isEditing={isEditing}
                         isLoaded={isLoaded}
                         isLoading={isLoading}
@@ -253,17 +265,24 @@ Request.propTypes = {
     files: PropTypes.arrayOf(PropTypes.string),
     supportingFiles: PropTypes.arrayOf(PropTypes.string),
   }).isRequired,
+  history: PropTypes.shape({
+    replace: PropTypes.func,
+  }).isRequired,
   isOutputChecker: PropTypes.bool.isRequired,
   isLoaded: PropTypes.bool.isRequired,
   isLoading: PropTypes.bool.isRequired,
   isSubmitting: PropTypes.bool.isRequired,
   location: PropTypes.shape({
+    pathname: PropTypes.string,
     state: PropTypes.shape({
       isEditing: PropTypes.bool,
     }),
   }).isRequired,
   updatedAt: PropTypes.string.isRequired,
   match: PropTypes.shape({
+    params: PropTypes.shape({
+      requestId: PropTypes.string,
+    }),
     url: PropTypes.string.isRequired,
   }).isRequired,
   onFinishEditing: PropTypes.func.isRequired,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

If user's saved files to a new request and then refreshed, the cached history state of `isEditing: true` would start the page in edit mode, which would trigger an error as the uploading view of the table doesn't have the request ID to make a proper file request. Now once the edit is complete the state is replaced with `isEditing` set to `false`.

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (non-breaking change with enhancements to documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](https://github.com/bcgov/OCWA/blob/master/CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
