### PR TITLE
Add the request ID to file requests when switching to the upload mode.

### DIFF
--- a/frontend/src/modules/files/containers/file-uploader.js
+++ b/frontend/src/modules/files/containers/file-uploader.js
@@ -43,11 +43,14 @@ const mapStateToProps = (state, props) => {
   };
 };
 
-export default connect(mapStateToProps, {
-  initialRequest: ({ ids = [] }) =>
-    fetchFiles({
-      url: `/api/v1/files?ids=${ids.join(',')}`,
-      schema: filesListSchema,
-    }),
-  onUpload: uploadFile,
-})(withRequest(FileUploader));
+export default connect(
+  mapStateToProps,
+  {
+    initialRequest: ({ id, ids = [] }) =>
+      fetchFiles({
+        url: `/api/v1/files?request_id=${id}&ids=${ids.join(',')}`,
+        schema: filesListSchema,
+      }),
+    onUpload: uploadFile,
+  }
+)(withRequest(FileUploader));

--- a/frontend/src/modules/requests/components/request/details.jsx
+++ b/frontend/src/modules/requests/components/request/details.jsx
@@ -90,6 +90,7 @@ function RequestDetails({
                 <FileUploader
                   data={uploadData}
                   filesKey="files"
+                  id={id}
                   uploadText="Upload files you wish to request for output"
                 />
               )}
@@ -107,6 +108,7 @@ function RequestDetails({
               {isEditing && (
                 <FileUploader
                   data={uploadData}
+                  id={id}
                   filesKey="supportingFiles"
                   uploadText="Upload any files to help support your request"
                 />


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description
The file upload component was missing the request ID, so if a request has some files added to it and then edits to add more, the files would not be found by the API.

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (non-breaking change with enhancements to documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](https://github.com/bcgov/OCWA/blob/master/CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
