### PR TITLE
Avoid making an edit call if it's on first load.

### DIFF
--- a/frontend/src/modules/requests/components/request/details.jsx
+++ b/frontend/src/modules/requests/components/request/details.jsx
@@ -25,6 +25,7 @@ function RequestDetails({
   isLoading,
   onSave,
 }) {
+  const editingRef = React.useRef(isEditing);
   const formRef = React.useRef({});
   const files = get(data, 'files', []);
   const supportingFiles = get(data, 'supportingFiles', []);
@@ -46,9 +47,11 @@ function RequestDetails({
   }, [data]);
 
   React.useEffect(() => {
-    if (!isEditing) {
+    if (!isEditing && editingRef.current === true) {
       onSave(id, formRef.current);
     }
+
+    editingRef.current = isEditing;
   }, [isEditing]);
 
   if (isLoading && !data._id) {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Prevents the Details component useEffect from firing if the form started off false (toggling edit state or if the request was newly created and started will still fire the save action).

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (non-breaking change with enhancements to documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](https://github.com/bcgov/OCWA/blob/master/CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
