### PR TITLE
Fix wrong version number for file download dialog.

### DIFF
--- a/frontend/src/modules/download/containers/downloads.js
+++ b/frontend/src/modules/download/containers/downloads.js
@@ -24,7 +24,7 @@ export default connect(mapStateToProps, {
   onCloseDownloads: closeDownloads,
   fetchFiles: ({ id, ids = [] }) =>
     fetchFiles({
-      url: `/api/v2/files?request_id=${id}&ids=${ids.join(',')}`,
+      url: `/api/v1/files?request_id=${id}&ids=${ids.join(',')}`,
       schema: filesListSchema,
     }),
 })(withRequest(Downloads));


### PR DESCRIPTION

# Description

Fixes a typo in the downloads dialog pointing to the wrong API version

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (non-breaking change with enhancements to documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x ] I have read the [CONTRIBUTING](https://github.com/bcgov/OCWA/blob/master/CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
